### PR TITLE
remove pysoundfile from environment.yml because it is not used in PCP

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,4 +14,3 @@ dependencies:
   - jupyter_contrib_nbextensions=0.5.*
   - pip:
     - nbstripout==0.3.*
-    - pysoundfile==0.9.*


### PR DESCRIPTION
We don't use pysoundfile in the PCP notebooks. Thus, I removed this dependency from the environment.yml file.